### PR TITLE
Add typescript typings

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="node" />
+
+declare function streamEqual(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadableStream, cb: streamEqual.Cb): undefined;
+declare function streamEqual(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadableStream): Promise<boolean>;
+
+declare namespace streamEqual {
+  export type Cb = (err: null|Error, equal: boolean) => void;
+}
+
+export= streamEqual;

--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
   },
   "author": "Roly Fentanes (https://github.com/fent)",
   "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
   "scripts": {
     "test": "istanbul cover node_modules/.bin/_mocha -- test/*-test.js"
   },
   "directories": {
     "lib": "./lib"
+  },
+  "dependencies": {
+    "@types/node": "*"
   },
   "devDependencies": {
     "istanbul": "*",


### PR DESCRIPTION
This PR would add type declarations so that typescript users are given type checking and smarter autocomplete when using the library.

The format for the typings follows the standard typescript [template](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html) for modules whose export is a function.